### PR TITLE
Fix the build on macOS

### DIFF
--- a/build/mac/usp.xcodeproj/project.pbxproj
+++ b/build/mac/usp.xcodeproj/project.pbxproj
@@ -661,8 +661,8 @@
 				INFOPLIST_FILE = "UnrealSpeccyPortable-Info.plist";
 				OTHER_CPLUSPLUSFLAGS = (
 					"$(OTHER_CFLAGS)",
-					"-I/opt/local/Library/Frameworks/wxWidgets.framework/Versions/wxWidgets/3.0/lib/wx/include/osx_cocoa-unicode-3.0",
-					"-I/opt/local/Library/Frameworks/wxWidgets.framework/Versions/wxWidgets/3.0/include/wx-3.0",
+					"-I/usr/local/lib/wx/include/osx_cocoa-unicode-3.0",
+					"-I/usr/local/include/wx-3.0",
 					"-D_FILE_OFFSET_BITS=64",
 					"-DWXUSINGDLL",
 					"-D__WXMAC__",
@@ -670,7 +670,7 @@
 					"-D__WXOSX_COCOA__",
 				);
 				OTHER_LDFLAGS = (
-					"-L/opt/local/Library/Frameworks/wxWidgets.framework/Versions/wxWidgets/3.0/lib",
+					"-L/usr/local/lib",
 					"-lwx_osx_cocoau_gl-3.0",
 					"-lwx_osx_cocoau_adv-3.0",
 					"-lwx_osx_cocoau_core-3.0",
@@ -694,8 +694,8 @@
 				LLVM_LTO = YES;
 				OTHER_CPLUSPLUSFLAGS = (
 					"$(OTHER_CFLAGS)",
-					"-I/opt/local/Library/Frameworks/wxWidgets.framework/Versions/wxWidgets/3.0/lib/wx/include/osx_cocoa-unicode-3.0",
-					"-I/opt/local/Library/Frameworks/wxWidgets.framework/Versions/wxWidgets/3.0/include/wx-3.0",
+					"-I/usr/local/lib/wx/include/osx_cocoa-unicode-3.0",
+					"-I/usr/local/include/wx-3.0",
 					"-D_FILE_OFFSET_BITS=64",
 					"-DWXUSINGDLL",
 					"-D__WXMAC__",
@@ -703,7 +703,7 @@
 					"-D__WXOSX_COCOA__",
 				);
 				OTHER_LDFLAGS = (
-					"-L/opt/local/Library/Frameworks/wxWidgets.framework/Versions/wxWidgets/3.0/lib",
+					"-L/usr/local/lib",
 					"-lwx_osx_cocoau_gl-3.0",
 					"-lwx_osx_cocoau_adv-3.0",
 					"-lwx_osx_cocoau_core-3.0",

--- a/build/mac/usp.xcodeproj/project.pbxproj
+++ b/build/mac/usp.xcodeproj/project.pbxproj
@@ -68,6 +68,12 @@
 		5C9485ED15F0116100985CF2 /* file_type_zip.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5C9485E915F0116100985CF2 /* file_type_zip.cpp */; };
 		5C9485EE15F0116100985CF2 /* file_type.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5C9485EA15F0116100985CF2 /* file_type.cpp */; };
 		5C9485EF15F0116100985CF2 /* speccy_handler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5C9485EC15F0116100985CF2 /* speccy_handler.cpp */; };
+		DA20793025C0B27C0098789D /* fdd_td0_lzh.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DA20792F25C0B27C0098789D /* fdd_td0_lzh.cpp */; };
+		DA69A6D025C0B15200987DDC /* fdd_fdi.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DA69A6CF25C0B15200987DDC /* fdd_fdi.cpp */; };
+		DA7C162925C0B1E6007285CE /* fdd_scl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DA7C162825C0B1E6007285CE /* fdd_scl.cpp */; };
+		DA7C162C25C0B1F3007285CE /* fdd_udi.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DA7C162B25C0B1F3007285CE /* fdd_udi.cpp */; };
+		DA7C162F25C0B20C007285CE /* fdd_trd.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DA7C162E25C0B20C007285CE /* fdd_trd.cpp */; };
+		DA7C163225C0B236007285CE /* fdd_td0.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DA7C163125C0B236007285CE /* fdd_td0.cpp */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -187,6 +193,12 @@
 		5C9485EB15F0116100985CF2 /* file_type.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = file_type.h; path = ../../file_type.h; sourceTree = SOURCE_ROOT; };
 		5C9485EC15F0116100985CF2 /* speccy_handler.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = speccy_handler.cpp; path = ../../speccy_handler.cpp; sourceTree = SOURCE_ROOT; };
 		5CA765F8119DD606000C0142 /* UnrealSpeccyPortable.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = UnrealSpeccyPortable.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		DA20792F25C0B27C0098789D /* fdd_td0_lzh.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = fdd_td0_lzh.cpp; sourceTree = "<group>"; };
+		DA69A6CF25C0B15200987DDC /* fdd_fdi.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = fdd_fdi.cpp; sourceTree = "<group>"; };
+		DA7C162825C0B1E6007285CE /* fdd_scl.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = fdd_scl.cpp; sourceTree = "<group>"; };
+		DA7C162B25C0B1F3007285CE /* fdd_udi.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = fdd_udi.cpp; sourceTree = "<group>"; };
+		DA7C162E25C0B20C007285CE /* fdd_trd.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = fdd_trd.cpp; sourceTree = "<group>"; };
+		DA7C163125C0B236007285CE /* fdd_td0.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = fdd_td0.cpp; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -407,6 +419,12 @@
 		5C6524EA1428C6DE0060688D /* fdd */ = {
 			isa = PBXGroup;
 			children = (
+				DA20792F25C0B27C0098789D /* fdd_td0_lzh.cpp */,
+				DA7C163125C0B236007285CE /* fdd_td0.cpp */,
+				DA7C162E25C0B20C007285CE /* fdd_trd.cpp */,
+				DA7C162B25C0B1F3007285CE /* fdd_udi.cpp */,
+				DA7C162825C0B1E6007285CE /* fdd_scl.cpp */,
+				DA69A6CF25C0B15200987DDC /* fdd_fdi.cpp */,
 				5C6524EB1428C6DE0060688D /* fdd.cpp */,
 				5C6524EC1428C6DE0060688D /* fdd.h */,
 				5C6524ED1428C6DE0060688D /* wd1793.cpp */,
@@ -553,6 +571,7 @@
 			files = (
 				5C24EBF0183982EC00771FDD /* profiler.cpp in Sources */,
 				5C24EB9A183962AD00771FDD /* pngget.c in Sources */,
+				DA7C162F25C0B20C007285CE /* fdd_trd.cpp in Sources */,
 				5C24EBA3183962AD00771FDD /* unzip.c in Sources */,
 				5C24EBC318396A8300771FDD /* wx_cmdline.cpp in Sources */,
 				5C24EB9F183962AD00771FDD /* pngwrite.c in Sources */,
@@ -563,6 +582,8 @@
 				5C6524671428C61C0060688D /* screenshot.cpp in Sources */,
 				5C24EBC418396A8300771FDD /* wx_frame.cpp in Sources */,
 				5C56D8C11AEC4EBF0036B690 /* io_select_zip.cpp in Sources */,
+				DA69A6D025C0B15200987DDC /* fdd_fdi.cpp in Sources */,
+				DA7C162C25C0B1F3007285CE /* fdd_udi.cpp in Sources */,
 				5C24EBA1183962AD00771FDD /* pngwutil.c in Sources */,
 				5C6524681428C61C0060688D /* snapshot.cpp in Sources */,
 				5C24EB98183962AD00771FDD /* png.c in Sources */,
@@ -580,6 +601,8 @@
 				5C6525041428C6DE0060688D /* fdd.cpp in Sources */,
 				5C24EB9C183962AD00771FDD /* pngset.c in Sources */,
 				5C24EBF1183982EC00771FDD /* sound_mixer.cpp in Sources */,
+				DA7C162925C0B1E6007285CE /* fdd_scl.cpp in Sources */,
+				DA7C163225C0B236007285CE /* fdd_td0.cpp in Sources */,
 				5C6525051428C6DE0060688D /* wd1793.cpp in Sources */,
 				5C6525061428C6DE0060688D /* kempston_joy.cpp in Sources */,
 				5C6525071428C6DE0060688D /* kempston_mouse.cpp in Sources */,
@@ -605,6 +628,7 @@
 				5C24EBC218396A8300771FDD /* wx_canvas.cpp in Sources */,
 				5C9485ED15F0116100985CF2 /* file_type_zip.cpp in Sources */,
 				5C9485EE15F0116100985CF2 /* file_type.cpp in Sources */,
+				DA20793025C0B27C0098789D /* fdd_td0_lzh.cpp in Sources */,
 				5C9485EF15F0116100985CF2 /* speccy_handler.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/build/mac/usp.xcodeproj/project.pbxproj
+++ b/build/mac/usp.xcodeproj/project.pbxproj
@@ -639,12 +639,14 @@
 		1DEB923608733DC60010E9CD /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ONLY_ACTIVE_ARCH = YES;
 			};
 			name = Debug;
 		};
 		1DEB923708733DC60010E9CD /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ONLY_ACTIVE_ARCH = YES;
 			};
 			name = Release;
 		};

--- a/file_type_zip.cpp
+++ b/file_type_zip.cpp
@@ -20,7 +20,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #ifdef USE_ZIP
 
-#include <unzip.h>
+#include "unzip.h"
 #include "platform/io.h"
 #include "options_common.h"
 #include "tools/stream_memory.h"

--- a/snapshot/screenshot.cpp
+++ b/snapshot/screenshot.cpp
@@ -20,7 +20,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #ifdef USE_PNG
 
-#include <png.h>
+#include "png.h"
 #include "../speccy.h"
 #include "../file_type.h"
 

--- a/tools/io_select_zip.cpp
+++ b/tools/io_select_zip.cpp
@@ -22,7 +22,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "../platform/io.h"
 #include "io_select.h"
-#include <unzip.h>
+#include "unzip.h"
 
 namespace xIo
 {

--- a/tools/options.cpp
+++ b/tools/options.cpp
@@ -20,7 +20,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "../platform/platform.h"
 
 #ifdef USE_CONFIG
-#include <tinyxml2.h>
+#include "tinyxml2.h"
 #include "../platform/io.h"
 #endif//USE_CONFIG
 


### PR DESCRIPTION
These are the changes I got to make in order to build the project in Xcode on macOS (note, I have zero experience in this, so these changes may be incorrect from the whole project perspective). Please see the details in the commit messages.

Right before posting the pull request, I realized that wxWidgets is meant to be installed as a Git submodule. But if I do so, the includes like `#include <wx/wx.h>` still won't work because the headers are unavailable system-wide.

Please let me know how you'd prefer to address the wxWidgets dependency issue. Or am I just installing it wrong?