### PR TITLE
Respect filtering option for UI overlay

### DIFF
--- a/platform/gles2/gles2.cpp
+++ b/platform/gles2/gles2.cpp
@@ -262,7 +262,7 @@ void eGLES2Impl::Draw(const ePoint& pos, const ePoint& size)
 		glActiveTexture(GL_TEXTURE0);
 		glBindTexture(GL_TEXTURE_2D, texture_ui);
 		glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, WIDTH, HEIGHT, GL_RGBA, GL_UNSIGNED_BYTE, texture_buffer_ui);
-		sprite_screen->Draw(texture_ui, pos, size, 0.99f, sx_ui, sy_ui); // force alpha blend
+		sprite_screen->Draw(texture_ui, pos, size, 0.99f, sx_ui, sy_ui, filtering); // force alpha blend
 	}
 #endif//USE_UI
 //	glFlush();


### PR DESCRIPTION
The UI overlay (bitmap font menu) was always rendered with GL_LINEAR, blurring it regardless of the user's Filtering setting. Pass the same filtering flag used for the screen so the overlay matches.

Filtering on:
<img width="1075" height="865" alt="filtering-on" src="https://github.com/user-attachments/assets/02f3704a-0d4c-4e81-9697-575708d70122" />

Filtering off:
<img width="1075" height="865" alt="filtering-off" src="https://github.com/user-attachments/assets/78b6dd0b-e20b-4993-920e-f596af5af8d5" />
